### PR TITLE
Add runtime Swagger MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The generator has been refactored into a proper Python package while maintaining
 You can use the tool in whatever way you prefer:
 1. Run `generator.py` directly (original approach)
 2. Install as a package and use `mcp-generator` command
-3. Use the module programmatically in your own Python code
+3. Use the runtime module programmatically in your own Python code
 
 For more details on the modular code structure, see [MODULAR_REFACTORING.md](MODULAR_REFACTORING.md).
 
@@ -72,25 +72,25 @@ pip install openapi-mcp-generator
 ## Usage
 
 ```bash
-# Using the original script (still works the same way)
+# Run a dynamic MCP server directly from an OpenAPI spec
+python -m swagger_mcp.cli openapi.yaml --api-url https://api.example.com
+
+# Generate a static project if needed
 python generator.py openapi.yaml --output-dir ./output --api-url https://api.example.com
-
-# Using the new modular CLI tool after installation
-mcp-generator openapi.yaml --output-dir ./output --api-url https://api.example.com
-
-# Using the python module directly
-python -m openapi_mcp_generator.cli openapi.yaml --output-dir ./output
 ```
 
 ### Command Line Options
 
-- `openapi_file`: Path to the OpenAPI YAML file (required)
-- `--output-dir`: Output directory for the generated project (default: '.')
+- `openapi_spec`: Path or URL to the OpenAPI specification
 - `--api-url`: Base URL for the API
 - `--auth-type`: Authentication type (bearer, token, basic)
 - `--api-token`: API token for authentication
 - `--api-username`: Username for basic authentication
 - `--api-password`: Password for basic authentication
+- `--include-pattern`: Only include operations matching this regex
+- `--exclude-pattern`: Exclude operations matching this regex
+- `--header`: Additional header `KEY=VALUE` (repeatable)
+- `--const`: Constant query parameter `KEY=VALUE` (repeatable)
 
 ## Running the Generated Server
 
@@ -131,6 +131,10 @@ openapi-mcp-generator/
 │   ├── http.py               # HTTP client utilities
 │   ├── parser.py             # OpenAPI parser
 │   └── project.py            # Project builder
+├── swagger_mcp/             # Runtime server package
+│   ├── __init__.py
+│   ├── cli.py
+│   └── runtime.py
 ├── templates/                # Original templates directory (used by the modular code)
 │   ├── config/
 │   ├── docker/
@@ -201,7 +205,8 @@ mcp-generator samples/TriliumNext/etapi.openapi.yaml
 Or use it programmatically in your own Python code:
 
 ```python
-from openapi_mcp_generator import generator
+from swagger_mcp.runtime import create_mcp_server
 
-generator.generate('samples/TriliumNext/etapi.openapi.yaml')
+mcp = create_mcp_server('samples/TriliumNext/etapi.openapi.yaml')
+mcp.run()
 ```

--- a/swagger_mcp/__init__.py
+++ b/swagger_mcp/__init__.py
@@ -1,0 +1,3 @@
+from .runtime import create_mcp_server
+
+__all__ = ["create_mcp_server"]

--- a/swagger_mcp/cli.py
+++ b/swagger_mcp/cli.py
@@ -1,0 +1,72 @@
+import argparse
+
+from .runtime import create_mcp_server
+
+
+def _parse_key_values(items):
+    result = {}
+    for item in items:
+        if "=" in item:
+            k, v = item.split("=", 1)
+            result[k.strip()] = v.strip()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run an MCP server directly from an OpenAPI specification"
+    )
+    parser.add_argument("openapi_spec", help="Path or URL to the OpenAPI spec")
+    parser.add_argument("--api-url", default="", help="Base URL for the API")
+    parser.add_argument(
+        "--auth-type",
+        choices=["bearer", "token", "basic"],
+        default="bearer",
+        help="Authentication type",
+    )
+    parser.add_argument("--api-token", default="", help="API token for auth")
+    parser.add_argument("--api-username", default="", help="Username for basic auth")
+    parser.add_argument("--api-password", default="", help="Password for basic auth")
+    parser.add_argument("--include-pattern", default="", help="Regex of operations to include")
+    parser.add_argument("--exclude-pattern", default="", help="Regex of operations to exclude")
+    parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        help="Extra header KEY=VALUE (repeatable)",
+    )
+    parser.add_argument(
+        "--const",
+        action="append",
+        default=[],
+        help="Constant query parameter KEY=VALUE (repeatable)",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["sse", "stdio"],
+        default="sse",
+        help="Transport type",
+    )
+
+    args = parser.parse_args()
+    headers = _parse_key_values(args.header)
+    consts = _parse_key_values(args.const)
+
+    mcp = create_mcp_server(
+        args.openapi_spec,
+        api_url=args.api_url,
+        auth_type=args.auth_type,
+        api_token=args.api_token,
+        api_username=args.api_username,
+        api_password=args.api_password,
+        headers=headers,
+        const_params=consts,
+        include_pattern=args.include_pattern or None,
+        exclude_pattern=args.exclude_pattern or None,
+    )
+
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/swagger_mcp/runtime.py
+++ b/swagger_mcp/runtime.py
@@ -1,0 +1,99 @@
+import json
+import re
+from typing import Any, Dict, Optional
+
+import httpx
+import yaml
+from mcp.server.fastmcp import Context, FastMCP
+
+from openapi_mcp_generator import generators, parser
+
+
+def _load_spec(source: str) -> Dict[str, Any]:
+    """Load an OpenAPI spec from a file, directory or URL."""
+    if re.match(r"https?://", source):
+        resp = httpx.get(source)
+        resp.raise_for_status()
+        text = resp.text
+        try:
+            return yaml.safe_load(text)
+        except yaml.YAMLError:
+            return json.loads(text)
+    return parser.parse_openapi_spec(source)
+
+
+def _filter_spec(spec: Dict[str, Any], include: Optional[str], exclude: Optional[str]) -> None:
+    inc_re = re.compile(include) if include else None
+    exc_re = re.compile(exclude) if exclude else None
+    for path in list(spec.get("paths", {})):
+        path_item = spec["paths"][path]
+        for method in list(path_item.keys()):
+            op = path_item[method]
+            op_id = op.get("operationId", "")
+            match = f"{method}:{path}:{op_id}"
+            if inc_re and not inc_re.search(match):
+                del path_item[method]
+                continue
+            if exc_re and exc_re.search(match):
+                del path_item[method]
+        if not path_item:
+            del spec["paths"][path]
+
+
+def create_mcp_server(
+    openapi_source: str,
+    *,
+    api_url: str = "",
+    auth_type: str = "bearer",
+    api_token: str = "",
+    api_username: str = "",
+    api_password: str = "",
+    headers: Optional[Dict[str, str]] = None,
+    const_params: Optional[Dict[str, str]] = None,
+    include_pattern: Optional[str] = None,
+    exclude_pattern: Optional[str] = None,
+) -> FastMCP:
+    """Create a FastMCP server from an OpenAPI specification."""
+
+    spec = _load_spec(openapi_source)
+    _filter_spec(spec, include_pattern, exclude_pattern)
+
+    mcp = FastMCP(name=spec.get("info", {}).get("title", "API"))
+    headers = headers or {}
+    const_params = const_params or {}
+
+    async def get_http_client() -> httpx.AsyncClient:
+        base_url = api_url
+        if not base_url and spec.get("servers"):
+            base_url = spec["servers"][0].get("url", "")
+        hdrs = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            **headers,
+        }
+        auth = None
+        if auth_type == "bearer" and api_token:
+            hdrs["Authorization"] = f"Bearer {api_token}"
+        elif auth_type == "token" and api_token:
+            hdrs["X-API-Key"] = api_token
+        elif auth_type == "basic" and api_username and api_password:
+            auth = httpx.BasicAuth(username=api_username, password=api_password)
+        return httpx.AsyncClient(base_url=base_url, headers=hdrs, auth=auth, timeout=30.0)
+
+    exec_globals = {
+        "mcp": mcp,
+        "Context": Context,
+        "httpx": httpx,
+        "get_http_client": get_http_client,
+        "const_query_params": const_params,
+    }
+
+    tool_defs = generators.generate_tool_definitions(spec)
+    if const_params:
+        tool_defs = tool_defs.replace(
+            "query_params = {}", "query_params = const_query_params.copy()"
+        )
+    resource_defs = generators.generate_resource_definitions(spec)
+    exec(tool_defs + "\n" + resource_defs, exec_globals)
+
+    return mcp

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,38 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from swagger_mcp.runtime import create_mcp_server
+
+
+async def _list_tool_names(mcp):
+    tools = await mcp.list_tools()
+    return [t.name for t in tools]
+
+
+def test_runtime_parses_tools():
+    mcp = create_mcp_server("tests/openapi.yaml", api_url="http://localhost")
+    tool_names = asyncio.run(_list_tool_names(mcp))
+    assert "getItems" in tool_names
+    assert "createLegacyItem" in tool_names
+
+
+def test_include_exclude_patterns():
+    mcp_inc = create_mcp_server(
+        "tests/openapi.yaml",
+        api_url="http://localhost",
+        include_pattern="legacy",
+    )
+    names_inc = asyncio.run(_list_tool_names(mcp_inc))
+    assert names_inc == ["createLegacyItem"]
+
+    mcp_exc = create_mcp_server(
+        "tests/openapi.yaml",
+        api_url="http://localhost",
+        exclude_pattern="legacy",
+    )
+    names_exc = asyncio.run(_list_tool_names(mcp_exc))
+    assert "createLegacyItem" not in names_exc
+    assert "getItems" in names_exc


### PR DESCRIPTION
## Summary
- implement dynamic runtime in `swagger_mcp/runtime.py`
- add CLI wrapper `swagger_mcp/cli.py`
- document new runtime workflow in README
- include unit tests for runtime server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b248c2d708321bdfaa5451014979e